### PR TITLE
Add a bunch of Improvements (a bit ad-hoc)

### DIFF
--- a/USCSandbox/Processor/ConstantBufferParameter.cs
+++ b/USCSandbox/Processor/ConstantBufferParameter.cs
@@ -7,8 +7,6 @@ namespace USCSandbox.Processor
         public string ParamName;
         public ShaderParamType ParamType;
         public int Rows;
-        //public int MatrixColumns;
-        //public int Columns => IsMatrix ? MatrixColumns : 1;
         public int Columns;
         public bool IsMatrix;
         public int ArraySize;
@@ -26,7 +24,6 @@ namespace USCSandbox.Processor
             ParamType = (ShaderParamType)r.ReadInt32();
             Rows = r.ReadInt32();
             Columns = r.ReadInt32();
-            //MatrixColumns = r.ReadInt32();
             IsMatrix = r.ReadInt32() > 0;
             ArraySize = r.ReadInt32();
             Index = r.ReadInt32();
@@ -41,14 +38,12 @@ namespace USCSandbox.Processor
             {
                 Rows = field["m_RowCount"].AsInt;
                 Columns = Rows;
-                //MatrixColumns = Rows; // is this right?
                 IsMatrix = true;
             }
             else
             {
                 Rows = field["m_Dim"].AsInt;
                 Columns = 1;
-                //MatrixColumns = Rows;
                 IsMatrix = false;
             }
         }

--- a/USCSandbox/Processor/FogMode.cs
+++ b/USCSandbox/Processor/FogMode.cs
@@ -1,0 +1,13 @@
+namespace USCSandbox.Processor
+{
+    public enum FogMode
+    {
+        Off = 0,
+        Linear = 1,
+        Exp = 2,
+        Exp2 = 3,
+        Count,
+
+        Unknown = -1,
+    }
+}

--- a/USCSandbox/Processor/ShaderGpuProgramType.cs
+++ b/USCSandbox/Processor/ShaderGpuProgramType.cs
@@ -67,7 +67,6 @@
         MetalFS = 24,
         SPIRV = 25,
         Console = 26,
-        //ConsoleVS = 26,
         ConsoleFS = 27,
         ConsoleHS = 28,
         ConsoleDS = 29,

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -40,10 +40,24 @@ namespace USCSandbox.Processor
             var compressedBlob = _shaderBf["compressedBlob.Array"].AsByteArray;
 
             var selectedIndex = platforms.IndexOf((int)_platformId);
-
-            var selectedOffset = offsets[selectedIndex]["Array"][0].AsUInt;
-            var selectedCompressedLength = compressedLengths[selectedIndex]["Array"][0].AsUInt;
-            var selectedDecompressedLength = decompressedLengths[selectedIndex]["Array"][0].AsUInt;
+            
+            uint selectedOffset;
+            if (offsets[selectedIndex].Children.Count > 0)
+                selectedOffset = offsets[selectedIndex]["Array"][0].AsUInt;
+            else
+                selectedOffset = offsets[selectedIndex].AsUInt;
+            
+            uint selectedCompressedLength;
+            if (compressedLengths[selectedIndex].Children.Count > 0)
+                selectedCompressedLength = compressedLengths[selectedIndex]["Array"][0].AsUInt;
+            else
+                selectedCompressedLength = compressedLengths[selectedIndex].AsUInt;
+            
+            uint selectedDecompressedLength;
+            if (offsets[selectedIndex].Children.Count > 0)
+                selectedDecompressedLength = decompressedLengths[selectedIndex]["Array"][0].AsUInt;
+            else
+                selectedDecompressedLength = decompressedLengths[selectedIndex].AsUInt;
 
             var decompressedBlob = new byte[selectedDecompressedLength];
             var lz4Decoder = new Lz4DecoderStream(new MemoryStream(compressedBlob));

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -420,13 +420,8 @@ namespace USCSandbox.Processor
                 bool nonGlobalCbuffer = cbuffer.Name != "$Globals";
                 int cbufferIndex = shaderParams.ConstantBuffers.IndexOf(cbuffer);
 
-                // if (nonGlobalCbuffer)
-                // {
-                //     sb.Append(new string(' ', depth * 4)); // todo: new stringbuilder
-                //     sb.AppendLine($"// CBUFFER_START({cbuffer.Name}) // {cbufferIndex}");
-                //     depth++;
-                // }
-
+                bool wroteCbufferHeaderYet = false;
+                
                 char[] chars = new char[] { 'x', 'y', 'z', 'w' };
                 List<ConstantBufferParameter> allParams = cbuffer.CBParams;
                 foreach (ConstantBufferParameter param in allParams)
@@ -438,6 +433,13 @@ namespace USCSandbox.Processor
                     if (UnityShaderConstants.INCLUDED_UNITY_PROP_NAMES.Contains(name))
                     {
                         continue;
+                    }
+                    
+                    if (!wroteCbufferHeaderYet && nonGlobalCbuffer)
+                    {
+                        sb.Append(new string(' ', depth * 4)); // todo: new stringbuilder
+                        sb.AppendLine($"// CBUFFER_START({cbuffer.Name}) // {cbufferIndex}");
+                        depth++;
                     }
 
                     if (!declaredCBufs.Contains(name))
@@ -458,14 +460,15 @@ namespace USCSandbox.Processor
                         }
                         declaredCBufs.Add(name);
                     }
-                }
 
-                // if (nonGlobalCbuffer)
-                // {
-                //     depth--;
-                //     sb.Append(new string(' ', depth * 4));
-                //     sb.AppendLine("// CBUFFER_END");
-                // }
+                    if (!wroteCbufferHeaderYet && nonGlobalCbuffer)
+                    {
+                        depth--;
+                        sb.Append(new string(' ', depth * 4));
+                        sb.AppendLine("// CBUFFER_END");
+                        wroteCbufferHeaderYet = true;
+                    }
+                }
             }
             return sb.ToString();
         }

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -628,6 +628,14 @@ namespace USCSandbox.Processor
             var passes = subshader["m_Passes.Array"];
             foreach (var pass in passes)
             {
+                var usePassName = pass["m_UseName"].AsString;
+                if (!string.IsNullOrEmpty(usePassName))
+                {
+                    _sb.AppendLine($"UsePass \"{usePassName}\"");
+                    continue;
+                }
+                // if (pass != passes.Last())
+                //     continue;
                 _sb.AppendLine("Pass {");
                 _sb.Indent();
                 {

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -820,10 +820,28 @@ namespace USCSandbox.Processor
             var stencilRef = state["stencilRef.val"].AsFloat;
             var stencilReadMask = state["stencilReadMask.val"].AsFloat;
             var stencilWriteMask = state["stencilWriteMask.val"].AsFloat;
-            var stencilOp = state["stencilOp"];
-            var stencilOpFront = state["stencilOpFront"];
-            var stencilOpBack = state["stencilOpBack"];
+            var stencilOpPass = (StencilOp)(int)state["stencilOp.pass.val"].AsFloat;
+            var stencilOpFail = (StencilOp)(int)state["stencilOp.fail.val"].AsFloat;
+            var stencilOpZfail = (StencilOp)(int)state["stencilOp.zFail.val"].AsFloat;
+            var stencilOpComp = (StencilComp)(int)state["stencilOp.comp.val"].AsFloat;
+            var stencilOpFrontPass = (StencilOp)(int)state["stencilOpFront.pass.val"].AsFloat;
+            var stencilOpFrontFail = (StencilOp)(int)state["stencilOpFront.fail.val"].AsFloat;
+            var stencilOpFrontZfail = (StencilOp)(int)state["stencilOpFront.zFail.val"].AsFloat;
+            var stencilOpFrontComp = (StencilComp)(int)state["stencilOpFront.comp.val"].AsFloat;
+            var stencilOpBackPass = (StencilOp)(int)state["stencilOpBack.pass.val"].AsFloat;
+            var stencilOpBackFail = (StencilOp)(int)state["stencilOpBack.fail.val"].AsFloat;
+            var stencilOpBackZfail = (StencilOp)(int)state["stencilOpBack.zFail.val"].AsFloat;
+            var stencilOpBackComp = (StencilComp)(int)state["stencilOpBack.comp.val"].AsFloat;
+            var fogMode = (FogMode)(int)state["fogMode"].AsFloat;
+            var fogColorX = state["fogColor.x.val"].AsFloat;
+            var fogColorY = state["fogColor.y.val"].AsFloat;
+            var fogColorZ = state["fogColor.z.val"].AsFloat;
+            var fogColorW = state["fogColor.w.val"].AsFloat;
+            var fogDensity = state["fogDensity.val"].AsFloat;
+            var fogStart = state["fogStart.val"].AsFloat;
+            var fogEnd = state["fogEnd.val"].AsFloat;
 
+            
             var lighting = state["lighting"].AsBool;
 
             if (alphaToMask > 0f)
@@ -838,9 +856,9 @@ namespace USCSandbox.Processor
             {
                 _sb.AppendLine($"ZTest {zTest}");
             }
-            if (zWrite == ZWrite.On)
+            if (zWrite != ZWrite.On)
             {
-                _sb.AppendLine("ZWrite On");
+                _sb.AppendLine($"ZWrite {zWrite}");
             }
             if (culling != CullMode.Back)
             {
@@ -850,6 +868,88 @@ namespace USCSandbox.Processor
             {
                 _sb.AppendLine($"Offset {offsetFactor}, {offsetUnits}");
             }
+            
+            if (stencilRef != 0.0 || stencilReadMask != 255.0 || stencilWriteMask != 255.0
+                || !(stencilOpPass == StencilOp.Keep && stencilOpFail == StencilOp.Keep && stencilOpZfail == StencilOp.Keep && stencilOpComp == StencilComp.Always)
+                || !(stencilOpFrontPass == StencilOp.Keep && stencilOpFrontFail == StencilOp.Keep && stencilOpFrontZfail == StencilOp.Keep && stencilOpFrontComp == StencilComp.Always)
+                || !(stencilOpBackPass == StencilOp.Keep && stencilOpBackFail == StencilOp.Keep && stencilOpBackZfail == StencilOp.Keep && stencilOpBackComp == StencilComp.Always))
+			{
+				_sb.AppendLine("Stencil {");
+                _sb.Indent();
+				if (stencilRef != 0.0)
+				{
+                    _sb.AppendLine($"Ref {stencilRef}");
+				}
+				if (stencilReadMask != 255.0)
+				{
+                    _sb.AppendLine($"ReadMask {stencilReadMask}");
+				}
+				if (stencilWriteMask != 255.0)
+				{
+                    _sb.AppendLine($"WriteMask {stencilWriteMask}");
+				}
+				if (stencilOpPass != StencilOp.Keep
+                    || stencilOpFail != StencilOp.Keep
+                    || stencilOpZfail != StencilOp.Keep
+                    || (stencilOpComp != StencilComp.Always && stencilOpComp != StencilComp.Disabled))
+				{
+                    _sb.AppendLine($"Comp {stencilOpComp}");
+                    _sb.AppendLine($"Pass {stencilOpPass}");
+                    _sb.AppendLine($"Fail {stencilOpFail}");
+                    _sb.AppendLine($"ZFail {stencilOpZfail}");
+				}
+				if (stencilOpFrontPass != StencilOp.Keep
+                    || stencilOpFrontFail != StencilOp.Keep
+                    || stencilOpFrontZfail != StencilOp.Keep
+                    || (stencilOpFrontComp != StencilComp.Always && stencilOpFrontComp != StencilComp.Disabled))
+				{
+                    _sb.AppendLine($"CompFront {stencilOpFrontComp}");
+                    _sb.AppendLine($"PassFront {stencilOpFrontPass}");
+                    _sb.AppendLine($"FailFront {stencilOpFrontFail}");
+                    _sb.AppendLine($"ZFailFront {stencilOpFrontZfail}");
+				}
+				if (stencilOpBackPass != StencilOp.Keep
+                    || stencilOpBackFail != StencilOp.Keep
+                    || stencilOpBackZfail != StencilOp.Keep
+                    || (stencilOpBackComp != StencilComp.Always && stencilOpBackComp != StencilComp.Disabled))
+				{
+                    _sb.AppendLine($"CompBack {stencilOpBackComp}");
+                    _sb.AppendLine($"PassBack {stencilOpBackPass}");
+                    _sb.AppendLine($"FailBack {stencilOpBackFail}");
+                    _sb.AppendLine($"ZFailBack {stencilOpBackZfail}");
+				}
+				_sb.Unindent();
+				_sb.AppendLine("}");
+			}
+
+			if (fogMode != FogMode.Unknown || fogDensity != 0.0 || fogStart != 0.0 || fogEnd != 0.0
+                || !(fogColorX == 0.0 && fogColorY == 0.0 && fogColorZ == 0.0 && fogColorW == 0.0))
+			{
+                _sb.AppendLine("Fog {");
+                _sb.Indent();
+				if (fogMode != FogMode.Unknown)
+				{
+                    _sb.AppendLine($"Mode {fogMode}");
+				}
+				if (fogColorX != 0.0 || fogColorY != 0.0 || fogColorZ != 0.0 || fogColorW != 0.0)
+				{
+                    _sb.AppendLine($"Color ({fogColorX.ToString(CultureInfo.InvariantCulture)}," +
+                                   $"{fogColorY.ToString(CultureInfo.InvariantCulture)}," +
+                                   $"{fogColorZ.ToString(CultureInfo.InvariantCulture)}," +
+                                   $"{fogColorW.ToString(CultureInfo.InvariantCulture)})");
+				}
+				if (fogDensity != 0.0)
+				{
+                    _sb.AppendLine($"Density {fogDensity.ToString(CultureInfo.InvariantCulture)}");
+				}
+				if (fogStart != 0.0 || fogEnd != 0.0)
+				{
+                    _sb.AppendLine($"Range {fogStart.ToString(CultureInfo.InvariantCulture)}, " +
+                                   $"{fogEnd.ToString(CultureInfo.InvariantCulture)}");
+				}
+                _sb.Unindent();
+                _sb.AppendLine("}");
+			}
 
             if (lighting)
             {

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -555,7 +555,7 @@ namespace USCSandbox.Processor
                     SerializedPropertyType.Color => "Color",
                     SerializedPropertyType.Vector => "Vector",
                     SerializedPropertyType.Float => "Float",
-                    SerializedPropertyType.Range => $"Range({defValues[0]}, {defValues[1]})",
+                    SerializedPropertyType.Range => $"Range({defValues[1]}, {defValues[2]})",
                     SerializedPropertyType.Texture => defTextureDim switch
                     {
                         1 => "any",

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -62,6 +62,8 @@ namespace USCSandbox.Processor
             {
                 WriteProperties(parsedForm["m_PropInfo"]);
                 WriteSubShaders(blobManager, parsedForm);
+                if (!string.IsNullOrEmpty(parsedForm["m_FallbackName"].AsString))
+                    _sb.AppendLine($"Fallback \"{parsedForm["m_FallbackName"].AsString}\"");
             }
             _sb.Unindent();
             _sb.AppendLine("}");

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -420,12 +420,12 @@ namespace USCSandbox.Processor
                 bool nonGlobalCbuffer = cbuffer.Name != "$Globals";
                 int cbufferIndex = shaderParams.ConstantBuffers.IndexOf(cbuffer);
 
-                if (nonGlobalCbuffer)
-                {
-                    sb.Append(new string(' ', depth * 4)); // todo: new stringbuilder
-                    sb.AppendLine($"CBUFFER_START({cbuffer.Name}) // {cbufferIndex}");
-                    depth++;
-                }
+                // if (nonGlobalCbuffer)
+                // {
+                //     sb.Append(new string(' ', depth * 4)); // todo: new stringbuilder
+                //     sb.AppendLine($"// CBUFFER_START({cbuffer.Name}) // {cbufferIndex}");
+                //     depth++;
+                // }
 
                 char[] chars = new char[] { 'x', 'y', 'z', 'w' };
                 List<ConstantBufferParameter> allParams = cbuffer.CBParams;
@@ -445,23 +445,27 @@ namespace USCSandbox.Processor
                         if (param.ArraySize > 0)
                         {
                             sb.Append(new string(' ', depth * 4));
+                            if (nonGlobalCbuffer)
+                                sb.Append("// ");
                             sb.AppendLine($"{typeName} {name}[{param.ArraySize}]; // {param.Index} (starting at cb{cbufferIndex}[{param.Index / 16}].{chars[param.Index % 16 / 4]})");
                         }
                         else
                         {
                             sb.Append(new string(' ', depth * 4));
+                            if (nonGlobalCbuffer && !cbuffer.Name.StartsWith("UnityPerDrawSprite"))
+                                sb.Append("// ");
                             sb.AppendLine($"{typeName} {name}; // {param.Index} (starting at cb{cbufferIndex}[{param.Index / 16}].{chars[param.Index % 16 / 4]})");
                         }
                         declaredCBufs.Add(name);
                     }
                 }
 
-                if (nonGlobalCbuffer)
-                {
-                    depth--;
-                    sb.Append(new string(' ', depth * 4));
-                    sb.AppendLine("CBUFFER_END");
-                }
+                // if (nonGlobalCbuffer)
+                // {
+                //     depth--;
+                //     sb.Append(new string(' ', depth * 4));
+                //     sb.AppendLine("// CBUFFER_END");
+                // }
             }
             return sb.ToString();
         }

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -1024,19 +1024,19 @@ namespace USCSandbox.Processor
                 }
                 else
                 {
-                    if (colMask == ColorWriteMask.Red)
+                    if ((colMask & ColorWriteMask.Red) == ColorWriteMask.Red)
                     {
                         _sb.AppendNoIndent("R");
                     }
-                    else if (colMask == ColorWriteMask.Green)
+                    if ((colMask & ColorWriteMask.Green) == ColorWriteMask.Green)
                     {
                         _sb.AppendNoIndent("G");
                     }
-                    else if (colMask == ColorWriteMask.Blue)
+                    if ((colMask & ColorWriteMask.Blue) == ColorWriteMask.Blue)
                     {
                         _sb.AppendNoIndent("B");
                     }
-                    else if (colMask == ColorWriteMask.Alpha)
+                    if ((colMask & ColorWriteMask.Alpha) == ColorWriteMask.Alpha)
                     {
                         _sb.AppendNoIndent("A");
                     }

--- a/USCSandbox/Processor/ShaderProcessor.cs
+++ b/USCSandbox/Processor/ShaderProcessor.cs
@@ -192,8 +192,6 @@ namespace USCSandbox.Processor
             
             foreach (var basket in basketsInfo)
             {
-                // if (basket != basketsInfo.Last())
-                //     continue;
                 var structSb = new StringBuilder();
                 var cbufferSb = new StringBuilder();
                 var texSb = new StringBuilder();
@@ -216,23 +214,11 @@ namespace USCSandbox.Processor
                 {
                     param = subProg.ShaderParams;
                 }
-
-                //Console.WriteLine($"working on {basket.SubProgramInfo.BlobIndex}");
-
+                
                 param.CombineCommon(progInfo);
 
                 var programType = subProg.GetProgramType(_engVer);
                 var graphicApi = _platformId;
-
-                // defineSb.Append(new string(' ', depth * 4));
-                // defineSb.AppendLine(programType switch
-                // {
-                //     ShaderGpuProgramType.DX11VertexSM40 => "#pragma vertex vert",
-                //     ShaderGpuProgramType.DX11PixelSM40 => "#pragma fragment frag",
-                //     ShaderGpuProgramType.ConsoleVS => "#pragma vertex vert",
-                //     ShaderGpuProgramType.ConsoleFS => "#pragma fragment frag",
-                //     _ => $"// unknown shader type {programType}"
-                // });
 
                 var keywords = subProg.GlobalKeywords.Concat(subProg.LocalKeywords).Order().ToArray();
 
@@ -271,48 +257,25 @@ namespace USCSandbox.Processor
                     structSb.Append(new string(' ', depth * 4));
                     structSb.Append($"#{preprocessorDirective} {string.Join(" && ", keywords)}");
                 }
-                // if (!keywords.SequenceEqual(["FOG_LINEAR", "POINT", "SHADOWS_CUBE", "SHADOWS_SOFT"]))
-                //     continue;
                 
-                // if ((!encounterdVert && programType == ShaderGpuProgramType.DX11VertexSM40)
-                //     || (!encounterdFrag && programType == ShaderGpuProgramType.DX11PixelSM40))
-                // {
-                    cbufferSb.Append(new string(' ', depth * 4));
-                    cbufferSb.AppendLine($"// CBs for {programType}");
-                //}
+                cbufferSb.Append(new string(' ', depth * 4));
+                cbufferSb.AppendLine($"// CBs for {programType}");
+                
                 foreach (ConstantBuffer cbuffer in param.ConstantBuffers)
                 {
-                    //if (!UnityShaderConstants.BUILTIN_CBUFFER_NAMES.Contains(cbuffer.Name))
-                    {
-                        cbufferSb.Append(WritePassCBuffer(param, declaredCBufs[string.Join("-", keywords)], cbuffer, depth));
-                    }
+                    cbufferSb.Append(WritePassCBuffer(param, declaredCBufs[string.Join("-", keywords)], cbuffer, depth));
                 }
 
-                //cbufferSb.AppendLine();
-                // if ((!encounterdVert && programType == ShaderGpuProgramType.DX11VertexSM40)
-                //     || (!encounterdFrag && programType == ShaderGpuProgramType.DX11PixelSM40))
-                // {
-                    texSb.Append(new string(' ', depth * 4));
-                    texSb.AppendLine($"// Textures for {programType}");
-                //}
+                texSb.Append(new string(' ', depth * 4));
+                texSb.AppendLine($"// Textures for {programType}");
 
                 texSb.Append(WritePassTextures(param, declaredCBufs[string.Join("-", keywords)], depth));
-                //texSb.AppendLine();
                 
                 switch (programType)
                 {
                     case ShaderGpuProgramType.DX11VertexSM40:
                     case ShaderGpuProgramType.DX11PixelSM40:
                     {
-                        // DBG
-                        // int ifDepth = 0;
-                        // foreach (var inst in conv.DxShader!.Shdr.shaderInstructions)
-                        // {
-                        //     memeSb.Append(new string(' ', depth * 4));
-                        //     memeSb.AppendLine("// " + DirectXDisassemblyHelper.DisassembleInstruction(inst, ref ifDepth));
-                        // }
-                        // ///
-
                         var conv = new USCShaderConverter();
                         conv.LoadDirectXCompiledShader(new MemoryStream(subProg.ProgramData), graphicApi, _engVer);
                         conv.ConvertDxShaderToUShaderProgram();
@@ -320,40 +283,6 @@ namespace USCSandbox.Processor
 
                         UShaderFunctionToHLSL hlslConverter = new UShaderFunctionToHLSL(conv.ShaderProgram!, depth);
                         
-
-                        //string preprocessorDirective;
-                        if ((!encounterdVert && programType == ShaderGpuProgramType.DX11VertexSM40)
-                            || (!encounterdFrag && programType == ShaderGpuProgramType.DX11PixelSM40))
-                        {
-                            
-
-                            //preprocessorDirective = "if";
-
-                            // codeSb.AppendLine();
-                            // codeSb.Append(new string(' ', depth * 4));
-                            // codeSb.Append("#if " + string.Join(" && ", keywords));
-                            // var keywordsSet = programType == ShaderGpuProgramType.DX11VertexSM40
-                            //     ? vertextUniqueKeywords
-                            //     : fragmentUniqueKeywords;
-                            // foreach (string excludedKeyword in keywordsSet.Except(keywords))
-                            // {
-                            //     codeSb.Append(" && ");
-                            //     codeSb.Append("!" + excludedKeyword);
-                            // }
-                            // codeSb.AppendLine();
-                        }
-                        else
-                        {
-                            //preprocessorDirective = "elif";
-                        }
-                        
-                        // structSb.AppendLine();
-                        // structSb.Append(new string(' ', depth * 4));
-                        // structSb.Append($"#{preprocessorDirective} {string.Join(" && ", keywords)}");
-                        // codeSb.AppendLine();
-                        // codeSb.Append(new string(' ', depth * 4));
-                        // codeSb.Append($"#{preprocessorDirective} {string.Join(" && ", keywords)}");
-
                         structSb.AppendLine();
                         codeSb.AppendLine();
                         
@@ -637,8 +566,7 @@ namespace USCSandbox.Processor
                     _sb.AppendLine($"UsePass \"{usePassName}\"");
                     continue;
                 }
-                // if (pass != passes.Last())
-                //     continue;
+                
                 _sb.AppendLine("Pass {");
                 _sb.Indent();
                 {
@@ -652,12 +580,7 @@ namespace USCSandbox.Processor
 
                     var vertProgInfos = vertInfo.GetForPlatform((int)GetVertexProgramForPlatform(_platformId));
                     var fragProgInfos = fragInfo.GetForPlatform((int)GetFragmentProgramForPlatform(_platformId));
-
-                    // if (vertProgInfos.Count != fragProgInfos.Count && fragProgInfos.Count > 0)
-                    // {
-                    //     throw new Exception("Vert and frag program count should be the same");
-                    // }
-
+                    
                     // we should hopefully only have one of each type, but just in case...
                     // todo: cleanup
                     List<ShaderProgramBasket> baskets = [];
@@ -673,116 +596,6 @@ namespace USCSandbox.Processor
                     }
                     if (baskets.Count > 0)
                         WritePassBody(blobManager, baskets, _sb.GetIndent());
-
-                    /*for (var i = 0; i < vertProgInfos.Count; i++)
-                    {
-                        var test = blobManager.GetShaderSubProgram((int)vertProgInfos[i].BlobIndex);
-                        var keys = test.GlobalKeywords.Concat(test.LocalKeywords).ToArray();
-                        if (!(keys.SequenceEqual(["DUMMY"]) || keys.SequenceEqual(["DIRECTIONAL", "DUMMY"])))
-                        {
-                            continue;
-                        }
-
-                        int fragId = -1;
-                        for (var j = 0; j < fragProgInfos.Count; j++)
-                        {
-                            test = blobManager.GetShaderSubProgram((int)fragProgInfos[j].BlobIndex);
-                            keys = test.GlobalKeywords.Concat(test.LocalKeywords).ToArray();
-                            if (!(keys.SequenceEqual(["DUMMY"]) || keys.SequenceEqual(["DIRECTIONAL", "DUMMY"])))
-                            {
-                                continue;
-                            }
-
-                            fragId = j;
-                            break;
-                        }
-
-                        List<ShaderProgramBasket> baskets;
-                        if (vertInfo.ParameterBlobIndices.Count > 0) //&& fragInfo.ParameterBlobIndices.Count > 0)
-                        {
-                            baskets = new List<ShaderProgramBasket>
-                            {
-                                new ShaderProgramBasket(vertInfo, vertProgInfos[i], (int)vertInfo.ParameterBlobIndices[i]),
-                                new ShaderProgramBasket(fragInfo, fragProgInfos[fragId], (int)fragInfo.ParameterBlobIndices[fragId])
-                            };
-                        }
-                        else
-                        {
-                            baskets = new List<ShaderProgramBasket>
-                            {
-                                new ShaderProgramBasket(vertInfo, vertProgInfos[i], -1),
-                                new ShaderProgramBasket(fragInfo, fragProgInfos[fragId], -1)
-                            };
-                        }
-                        WritePassBody(blobManager, baskets, _sb.GetIndent());
-                    }*/
-                    /*if (vertProgInfos.Count > 0 && fragProgInfos.Count > 0)
-                    {
-                        for (var i = 0; i < vertProgInfos.Count; i++)
-                        {
-                            List<ShaderProgramBasket> baskets;
-                            if (vertInfo.ParameterBlobIndices.Count > 0 && vertInfo.ParameterBlobIndices.Count > 0)
-                            {
-                                baskets = new List<ShaderProgramBasket>
-                                {
-                                    new ShaderProgramBasket(vertInfo, vertProgInfos[i], (int)vertInfo.ParameterBlobIndices[i]),
-                                    //new ShaderProgramBasket(fragInfo, fragProgInfos[i], (int)fragInfo.ParameterBlobIndices[i])
-                                };
-                            }
-                            else
-                            {
-                                baskets = new List<ShaderProgramBasket>
-                                {
-                                    new ShaderProgramBasket(vertInfo, vertProgInfos[i], -1),
-                                    //new ShaderProgramBasket(fragInfo, fragProgInfos[i], -1)
-                                };
-                            }
-                            WritePassBody(blobManager, baskets, _sb.GetIndent());
-                        }
-                        for (var i = 0; i < fragProgInfos.Count; i++)
-                        {
-                            List<ShaderProgramBasket> baskets;
-                            if (vertInfo.ParameterBlobIndices.Count > 0 && fragInfo.ParameterBlobIndices.Count > 0)
-                            {
-                                baskets = new List<ShaderProgramBasket>
-                                {
-                                    new ShaderProgramBasket(fragInfo, fragProgInfos[i], (int)fragInfo.ParameterBlobIndices[i]),
-                                    //new ShaderProgramBasket(fragInfo, fragProgInfos[i], (int)fragInfo.ParameterBlobIndices[i])
-                                };
-                            }
-                            else
-                            {
-                                baskets = new List<ShaderProgramBasket>
-                                {
-                                    new ShaderProgramBasket(fragInfo, fragProgInfos[i], -1),
-                                    //new ShaderProgramBasket(fragInfo, fragProgInfos[i], -1)
-                                };
-                            }
-                            WritePassBody(blobManager, baskets, _sb.GetIndent());
-                        }
-                    }
-                    else if (vertProgInfos.Count > 0 && fragProgInfos.Count == 0)
-                    {
-                        for (var i = 0; i < vertProgInfos.Count; i++)
-                        {
-                            List<ShaderProgramBasket> baskets;
-                            if (vertInfo.ParameterBlobIndices.Count > 0)
-                            {
-                                baskets = new List<ShaderProgramBasket>
-                                {
-                                    new ShaderProgramBasket(vertInfo, vertProgInfos[i], (int)vertInfo.ParameterBlobIndices[i]),
-                                };
-                            }
-                            else
-                            {
-                                baskets = new List<ShaderProgramBasket>
-                                {
-                                    new ShaderProgramBasket(vertInfo, vertProgInfos[i], -1),
-                                };
-                            }
-                            WritePassBody(blobManager, baskets, _sb.GetIndent());
-                        }
-                    }*/
                 }
                 _sb.Unindent();
                 _sb.AppendLine("}");

--- a/USCSandbox/Processor/StencilComp.cs
+++ b/USCSandbox/Processor/StencilComp.cs
@@ -1,0 +1,18 @@
+namespace USCSandbox.Processor
+{
+    public enum StencilComp
+    {
+        Disabled = 0,
+        Never = 1,
+        Less = 2,
+        Equal = 3,
+        LEqual = 4,
+        Greater = 5,
+        NotEqual = 6,
+        GEqual = 7,
+        Always = 8,
+        Count,
+
+        Unknown = -1,
+    }
+}

--- a/USCSandbox/Processor/StencilOp.cs
+++ b/USCSandbox/Processor/StencilOp.cs
@@ -1,0 +1,15 @@
+namespace USCSandbox.Processor
+{
+    public enum StencilOp
+    {
+        Keep = 0,
+        Zero = 1,
+        Replace = 2,
+        IncrSat = 3,
+        DecrSat = 4,
+        Invert = 5,
+        IncrWrap = 6,
+        DecrWrap = 7,
+        Count,
+    }
+}

--- a/USCSandbox/Processor/UnityShaderConstants.cs
+++ b/USCSandbox/Processor/UnityShaderConstants.cs
@@ -13,8 +13,7 @@
             "unity_DynamicNormal",
             "unity_SpecCube0",
             "unity_SpecCube1",
-            "unity_ProbeVolumeSH",
-            "_ShadowMapTexture"
+            "unity_ProbeVolumeSH"
         };
 
         // TODO: same here

--- a/USCSandbox/Processor/UnityShaderConstants.cs
+++ b/USCSandbox/Processor/UnityShaderConstants.cs
@@ -57,7 +57,8 @@
             "_WorldSpaceCameraPos",
             "_WorldSpaceLightPos0",
             "_ZBufferParams",
-            "_LightPositionRange"
+            "_LightPositionRange",
+            "_PPLAmbient"
         };
 
         // not in cgincludes but needed

--- a/USCSandbox/Program.cs
+++ b/USCSandbox/Program.cs
@@ -9,15 +9,21 @@ namespace USCSandbox
     {
         static void Main(string[] args)
         {
+            // null "C:\Users\nesquack\Documents\GitIssueWs\Data2g\Data2\Resources\unity_builtin_extra" 7 Switch
+
             var bundlePath = args[0];
             var assetsFileName = args[1];
-            var shaderPathId = long.Parse(args[2]);
+            var shaderPathId = -1L; 
+            if (args.Length > 2)
+                shaderPathId = long.Parse(args[2]);
             var shaderPlatform = args.Length > 3 ? Enum.Parse<GPUPlatform>(args[3]) : GPUPlatform.d3d11;
 
             AssetsManager manager = new AssetsManager();
             AssetsFileInstance afileInst;
             AssetsFile afile;
             UnityVersion ver;
+            int shaderTypeId;
+            Dictionary<long, string> files = [];
             if (bundlePath != "null")
             {
                 var bundleFile = manager.LoadBundleFile(bundlePath, true);
@@ -26,6 +32,20 @@ namespace USCSandbox
                 manager.LoadClassPackage("classdata.tpk");
                 manager.LoadClassDatabaseFromPackage(bundleFile.file.Header.EngineVersion);
                 ver = UnityVersion.Parse(bundleFile.file.Header.EngineVersion);
+                shaderTypeId = manager.ClassPackage.GetClassDatabase(ver.ToString()).FindAssetClassByName("Shader").ClassId;
+                
+                var ggm = manager.LoadAssetsFileFromBundle(bundleFile, "globalgamemanagers");
+                //manager.LoadClassDatabaseFromPackage(ggm.file.Metadata.UnityVersion);
+                var rsrcInfo = ggm.file.GetAssetsOfType(AssetClassID.ResourceManager)[0];
+                var rsrcBf = manager.GetBaseField(ggm, rsrcInfo);
+                var m_Container = rsrcBf["m_Container.Array"];
+                foreach (var data in m_Container.Children)
+                {
+                    var name = data[0].AsString;
+                    var pathId = data[1]["m_PathID"].AsLong;
+                    files[pathId] = name;
+                    //Console.WriteLine($"in resources.assets, pathid {pathId} = {name}");
+                }
             }
             else
             {
@@ -34,16 +54,39 @@ namespace USCSandbox
                 manager.LoadClassPackage("classdata.tpk");
                 manager.LoadClassDatabaseFromPackage(afile.Metadata.UnityVersion);
                 ver = UnityVersion.Parse(afile.Metadata.UnityVersion);
+                shaderTypeId = manager.ClassPackage.GetClassDatabase(ver.ToString()).FindAssetClassByName("Shader").ClassId;
             }
 
-            var shaderBf = manager.GetExtAsset(afileInst, 0, shaderPathId).baseField;
-            if (shaderBf == null)
+            var shaders = afileInst.file.GetAssetsOfType(shaderTypeId);
+            int unnamedCount = 0;
+            foreach (var shader in shaders)
             {
-                Console.WriteLine("Shader asset not found.");
-                return;
+                if (shaderPathId != -1 && shader.PathId != shaderPathId)
+                    continue;
+                
+                var shaderBf = manager.GetExtAsset(afileInst, 0, shader.PathId).baseField;
+                if (shaderBf == null)
+                {
+                    Console.WriteLine("Shader asset not found.");
+                    return;
+                }
+                var shaderProcessor = new ShaderProcessor(shaderBf, ver, shaderPlatform);
+                bool fileNameExists = files.TryGetValue(shader.PathId, out string? name);
+                string shaderText = shaderProcessor.Process();
+                if (fileNameExists)
+                {
+                    Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, "out", Path.GetDirectoryName(name)!));
+                    File.WriteAllText($"{Path.Combine(Environment.CurrentDirectory, "out", name)}.shader", shaderText);
+                    Console.WriteLine($"{name} decompiled");
+                }
+                else
+                {
+                    Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, "out", "unnamed"));
+                    File.WriteAllText($"{Path.Combine(Environment.CurrentDirectory, "out", "unnamed", $"unnamed {unnamedCount}")}.shader", shaderText);
+                    Console.WriteLine($"Unnamed {unnamedCount} decompiled");
+                    unnamedCount++;
+                }
             }
-            var shaderProcessor = new ShaderProcessor(shaderBf, ver, shaderPlatform);
-            Console.WriteLine(shaderProcessor.Process());
         }
     }
 }

--- a/USCSandbox/Program.cs
+++ b/USCSandbox/Program.cs
@@ -58,7 +58,6 @@ namespace USCSandbox
             }
 
             var shaders = afileInst.file.GetAssetsOfType(shaderTypeId);
-            int unnamedCount = 0;
             foreach (var shader in shaders)
             {
                 if (shaderPathId != -1 && shader.PathId != shaderPathId)
@@ -81,10 +80,10 @@ namespace USCSandbox
                 }
                 else
                 {
-                    Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, "out", "unnamed"));
-                    File.WriteAllText($"{Path.Combine(Environment.CurrentDirectory, "out", "unnamed", $"unnamed {unnamedCount}")}.shader", shaderText);
-                    Console.WriteLine($"Unnamed {unnamedCount} decompiled");
-                    unnamedCount++;
+                    Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, "out", "builtin"));
+                    var shaderName = shaderBf["m_ParsedForm"]["m_Name"].AsString;
+                    File.WriteAllText($"{Path.Combine(Environment.CurrentDirectory, "out", "builtin", $"{shaderName.Replace('/', '_')}")}.shader", shaderText);
+                    Console.WriteLine($"builtin {shaderName} decompiled");
                 }
             }
         }

--- a/USCSandbox/Program.cs
+++ b/USCSandbox/Program.cs
@@ -9,8 +9,6 @@ namespace USCSandbox
     {
         static void Main(string[] args)
         {
-            // null "C:\Users\nesquack\Documents\GitIssueWs\Data2g\Data2\Resources\unity_builtin_extra" 7 Switch
-
             var bundlePath = args[0];
             var assetsFileName = args[1];
             var shaderPathId = -1L; 
@@ -35,7 +33,6 @@ namespace USCSandbox
                 shaderTypeId = manager.ClassPackage.GetClassDatabase(ver.ToString()).FindAssetClassByName("Shader").ClassId;
                 
                 var ggm = manager.LoadAssetsFileFromBundle(bundleFile, "globalgamemanagers");
-                //manager.LoadClassDatabaseFromPackage(ggm.file.Metadata.UnityVersion);
                 var rsrcInfo = ggm.file.GetAssetsOfType(AssetClassID.ResourceManager)[0];
                 var rsrcBf = manager.GetBaseField(ggm, rsrcInfo);
                 var m_Container = rsrcBf["m_Container.Array"];
@@ -44,7 +41,6 @@ namespace USCSandbox
                     var name = data[0].AsString;
                     var pathId = data[1]["m_PathID"].AsLong;
                     files[pathId] = name;
-                    //Console.WriteLine($"in resources.assets, pathid {pathId} = {name}");
                 }
             }
             else

--- a/USCSandbox/USCSandbox.csproj
+++ b/USCSandbox/USCSandbox.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/USCSandbox/UltraShaderConverter/DirectXDisassembler/Blocks/SHDR.cs
+++ b/USCSandbox/UltraShaderConverter/DirectXDisassembler/Blocks/SHDR.cs
@@ -111,11 +111,6 @@
                 }
             }
 
-            //for (int i = 0; i < GetOperandCount(opcode); i++)
-            //{
-            //    operands.Add(new SHDRInstructionOperand(reader));
-            //}
-
             if (reader.BaseStream.Position > endPos && opcode != Opcode.customdata)
             {
                 throw new Exception($"went over end pos ({opcode})");
@@ -596,17 +591,6 @@
                 }
                 case Opcode.dcl_indexrange:
                 {
-                    //reader.BaseStream.Position += extraDataStart;
-                    //indexRange = reader.ReadInt32();
-                    //if (inst.operands[0].operand == Operand.Input)
-                    //{
-                    //    int reg = inst.operands[0].arraySizes.Length;
-                    //    
-                    //}
-                    //else if (inst.operands[0].operand == Operand.Output)
-                    //{
-                    //
-                    //}
                     break;
                 }
                 case Opcode.dcl_constantbuffer:

--- a/USCSandbox/UltraShaderConverter/DirectXDisassembler/DirectXDisassemblyHelper.cs
+++ b/USCSandbox/UltraShaderConverter/DirectXDisassembler/DirectXDisassemblyHelper.cs
@@ -6,7 +6,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.DirectXDisasse
     {
         public static string DisassembleInstruction(SHDRInstruction inst, ref int ifDepth)
         {
-            if (inst.opcode == Opcode.endif || inst.opcode == Opcode.@else)
+            if (ifDepth > 0 && (inst.opcode == Opcode.endif || inst.opcode == Opcode.@else))
             {
                 ifDepth -= 2;
             }

--- a/USCSandbox/UltraShaderConverter/USIL/Fixers/USILGetDimensionsFixer.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Fixers/USILGetDimensionsFixer.cs
@@ -46,30 +46,6 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Fixers
 
                 resinfoInst.srcOperands[5] = sampleinfoInst.destOperand;
 
-                //USILInstruction usilInst = new USILInstruction();
-                //USILOperand usilResource = new USILOperand(resinfoInst.srcOperands[0]);
-                //USILOperand usilMipLevel = new USILOperand(resinfoInst.srcOperands[1]);
-                //USILOperand usilWidth = new USILOperand(resinfoInst.srcOperands[2]);
-                //USILOperand usilHeight = new USILOperand(resinfoInst.srcOperands[3]);
-                //USILOperand usilDepthOrArraySize = new USILOperand(resinfoInst.srcOperands[4]);
-                //USILOperand usilMipCount  = new USILOperand(resinfoInst.srcOperands[5]);
-                //USILOperand usilSampleCount = new USILOperand(sampleinfoInst.destOperand);
-
-                //usilInst.instructionType = USILInstructionType.GetDimensions;
-                //usilInst.destOperand = null;
-                //usilInst.srcOperands = new List<USILOperand>
-                //{
-                //	usilResource,
-                //	usilMipLevel,
-                //	usilWidth,
-                //	usilHeight,
-                //	usilDepthOrArraySize,
-                //	usilMipCount,
-                //	usilSampleCount
-                //};
-
-                //instructions[i] = usilInst;
-
                 instructions.RemoveAt(i + 1); // remove SampleCountInfo
                 changes = true;
             }

--- a/USCSandbox/UltraShaderConverter/USIL/Fixers/USILObviousUIntFixer.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Fixers/USILObviousUIntFixer.cs
@@ -32,8 +32,8 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Fixers
                         operand.immValueInt = new int[count];
                         for (int j = 0; j < count; j++)
                         {
-                            int intValue = BitConverter.SingleToInt32Bits(operand.immValueFloat[j]);
-                            operand.immValueInt[j] = intValue;
+                            //int intValue = BitConverter.SingleToInt32Bits(operand.immValueFloat[j]);
+                            operand.immValueInt[j] = (int)operand.immValueFloat[j];
                         }
                         operand.operandType = USILOperandType.ImmediateInt;
                     }

--- a/USCSandbox/UltraShaderConverter/USIL/Fixers/USILSamplerTypeFixer.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Fixers/USILSamplerTypeFixer.cs
@@ -15,8 +15,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Fixers
             "unity_ShadowMask",
             "unity_DynamicLightmap",
             "unity_SpecCube0",
-            "unity_ProbeVolumeSH",
-            "_ShadowMapTexture"
+            "unity_ProbeVolumeSH"
         };
 
         public bool Run(UShaderProgram shader, ShaderParams shaderParams)

--- a/USCSandbox/UltraShaderConverter/USIL/Metadders/USILCBufferMetadder.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Metadders/USILCBufferMetadder.cs
@@ -38,6 +38,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
 
                 HashSet<ConstantBufferParameter> cbParams = new HashSet<ConstantBufferParameter>();
                 List<int> cbMasks = new List<int>();
+                int cbParamIndex = 0;
 
                 ConstantBuffer constantBuffer;
                 BufferBinding? binding = shaderParams.ConstBindings.FirstOrDefault(b => b.Index == cbRegIdx);
@@ -63,8 +64,9 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
                 foreach (ConstantBufferParameter param in constantBuffer.CBParams)
                 {
                     int paramCbStart = param.Index;
-                    int paramCbSize = param.Rows * param.Columns * 4;
-                    int paramCbEnd = paramCbStart + paramCbSize;
+                    int paramCbElementSize = param.Rows * param.Columns * 4;
+                    int paramCbTotalSize = param.Rows * param.Columns * 4 * (param.ArraySize == 0 ? 1 : param.ArraySize);
+                    int paramCbEnd = paramCbStart + paramCbTotalSize;
 
                     foreach (int operandMaskAddress in operandMaskAddresses)
                     {
@@ -77,6 +79,13 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
                             {
                                 maskIndex %= 4;
                             }
+
+                            if (param.ArraySize > 1)
+                            {
+                                cbParamIndex = (operandMaskAddress - paramCbStart) / paramCbElementSize;
+                                maskIndex -= 4 * cbParamIndex;
+                            }
+                            
                             cbMasks.Add(maskIndex);
                         }
                     }

--- a/USCSandbox/UltraShaderConverter/USIL/Metadders/USILCBufferMetadder.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Metadders/USILCBufferMetadder.cs
@@ -80,7 +80,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
                                 maskIndex %= 4;
                             }
 
-                            if (param.ArraySize > 1)
+                            else if (param.ArraySize > 1)
                             {
                                 cbParamIndex = (operandMaskAddress - paramCbStart) / paramCbElementSize;
                                 maskIndex -= 4 * cbParamIndex;
@@ -147,27 +147,29 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
                 {
                     ConstantBufferParameter param = cbParams.First();
 
-                    // Matrix
+                    operand.arrayIndex -= param.Index / 16;
+
+                    // apparently switch has column long, whereas directx has row long
+                    int maxRowOrColumnLength = Math.Max(param.Rows, param.Columns);
+
                     if (param.IsMatrix)
                     {
-                        //int matrixIdx = cbArrIdx - param.Index / 16;
+                        if (param.ArraySize > 0)
+                        {
+                            // example of 4x4 matrix: matrix[5] -> matrix[1][1] (matrix[1]._m01._m11._m21._m31)
+                            operand.arrayRelative = new USILOperand(operand.arrayIndex / maxRowOrColumnLength);
+                            operand.arrayIndex %= maxRowOrColumnLength;
+                        }
 
                         operand.operandType = USILOperandType.Matrix;
-                        //operand.arrayIndex = matrixIdx;
                         operand.transposeMatrix = true;
                     }
-                    //else
-                    //{
-                    operand.arrayIndex -= param.Index / 16;
-                    //}
 
                     operand.mask = cbMasks.ToArray();
                     operand.metadataName = param.ParamName;
                     operand.metadataNameAssigned = true;
                     operand.metadataNameWithArray = param.ArraySize > 1;
 
-                    // apparently switch has column long, whereas directx has row long
-                    int maxRowOrColumnLength = Math.Max(param.Rows, param.Columns);
                     if (cbMasks.Count == maxRowOrColumnLength && !param.IsMatrix)
                     {
                         operand.displayMask = false;

--- a/USCSandbox/UltraShaderConverter/USIL/Metadders/USILSamplerMetadder.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Metadders/USILSamplerMetadder.cs
@@ -19,7 +19,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
                         //    p => p.SamplerIndex == operand.registerIndex
                         //);
                         TextureParameter? texParam = shaderParams.TextureParameters.FirstOrDefault(
-                            p => p.Index == operand.registerIndex
+                            p => p.SamplerIndex == operand.registerIndex
                         );
 
                         if (texParam == null)

--- a/USCSandbox/UltraShaderConverter/USIL/Metadders/USILSamplerMetadder.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Metadders/USILSamplerMetadder.cs
@@ -24,9 +24,17 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
 
                         if (texParam == null)
                         {
-                            operand.operandType = USILOperandType.Sampler2D;
-                            Logger.Warning($"Could not find texture parameter for sampler {operand}");
-                            continue;
+                            // fallback to -1 if it exists
+                            texParam = shaderParams.TextureParameters.FirstOrDefault(
+                                p => p.SamplerIndex == -1
+                            );
+                            
+                            if (texParam == null)
+                            {
+                                operand.operandType = USILOperandType.Sampler2D;
+                                Logger.Warning($"Could not find texture parameter for sampler {operand}");
+                                continue;
+                            }
                         }
 
                         int dimension = texParam.Dim;

--- a/USCSandbox/UltraShaderConverter/USIL/Metadders/USILSamplerMetadder.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/Metadders/USILSamplerMetadder.cs
@@ -15,9 +15,6 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL.Metadders
                 {
                     if (operand.operandType == USILOperandType.SamplerRegister)
                     {
-                        //TextureParameter? texParam = shaderParams.TextureParameters.FirstOrDefault(
-                        //    p => p.SamplerIndex == operand.registerIndex
-                        //);
                         TextureParameter? texParam = shaderParams.TextureParameters.FirstOrDefault(
                             p => p.SamplerIndex == operand.registerIndex
                         );

--- a/USCSandbox/UltraShaderConverter/USIL/USILOperand.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/USILOperand.cs
@@ -211,7 +211,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL
                         {
                             body = $"{immValueInt[0]}";
                         }
-                        else //if (immValueInt.Length > 1)
+                        else
                         {
                             body += $"int{immValueInt.Length}(";
                             for (int i = 0; i < immValueInt.Length; i++)
@@ -237,7 +237,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL
                             // todo: float precision isn't correct atm. add precision check somewhere.
                             body = $"{immValueFloat[0].ToString("0.0#######", CultureInfo.InvariantCulture)}";
                         }
-                        else //if (immValueFloat.Length > 1)
+                        else
                         {
                             // todo: if all numbers are the same and it matches the mask, use it only once
                             body += $"float{immValueFloat.Length}(";

--- a/USCSandbox/UltraShaderConverter/USIL/USILOptimizerApplier.cs
+++ b/USCSandbox/UltraShaderConverter/USIL/USILOptimizerApplier.cs
@@ -32,7 +32,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.USIL
 			// do simplification optimizers last when detection has been finished
 			new USILCompareOrderOptimizer(),
             new USILAddNegativeOptimizer(),
-            new USILAndOptimizer(),
+            // new USILAndOptimizer(),
             // needs to be after AndOptimizer
             new USILObviousUIntFixer(),
             // //////////////////////////////

--- a/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
+++ b/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
@@ -852,7 +852,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
             {
                 usilInst.instructionType = USILInstructionType.FloatToInt;
             }
-            else // if (inst.opcode == Opcode.ftoi)
+            else
             {
                 usilInst.instructionType = USILInstructionType.FloatToUInt;
             }
@@ -882,7 +882,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
             {
                 usilInst.instructionType = USILInstructionType.IntToFloat;
             }
-            else // if (inst.opcode == Opcode.utof)
+            else
             {
                 usilInst.instructionType = USILInstructionType.UIntToFloat;
             }
@@ -1455,7 +1455,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
             {
                 usilInst.instructionType = USILInstructionType.SampleComparison;
             }
-            else //if (inst.opcode == Opcode.sample_c_lz)
+            else
             {
                 usilInst.instructionType = USILInstructionType.SampleComparisonLODZero;
             }
@@ -1504,7 +1504,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
             {
                 usilInst.instructionType = USILInstructionType.SampleLODBias;
             }
-            else //if (inst.opcode == Opcode.sample_l)
+            else
             {
                 usilInst.instructionType = USILInstructionType.SampleLOD;
             }
@@ -1588,7 +1588,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
             {
                 usilInst.instructionType = USILInstructionType.LoadResource;
             }
-            else //(inst.opcode == Opcode.ldms)
+            else
             {
                 usilInst.instructionType = USILInstructionType.LoadResourceMultisampled;
             }

--- a/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
+++ b/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
@@ -412,6 +412,15 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
                                 ConvertFloatToInt((float)dxOperand.immValues[0])
                             };
                         }
+                        else if (double.IsNaN(dxOperand.immValues[0]) 
+                                 || Math.Abs(((BitConverter.DoubleToInt64Bits(dxOperand.immValues[0]) >> 52) & 0x7ff) - 1023)
+                                     is > 100 and < 1023)
+                        {
+                            usilOperand.immValueFloat = new float[1]
+                            {
+                                ConvertFloatToInt((float)dxOperand.immValues[0])
+                            };
+                        }
                         else
                         {
                             usilOperand.immValueFloat = new float[1]
@@ -430,12 +439,31 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
                                 usilOperand.immValueInt[i] = ConvertFloatToInt((float)dxOperand.immValues[mask[i]]);
                             }
                         }
-                        else
+                        else if (dxOperand.immValues
+                                 .Any(x => double.IsNaN(x) 
+                                           || Math.Abs(((BitConverter.DoubleToInt64Bits(x) >> 52) & 0x7ff) - 1023)
+                                               is > 100 and < 1023))
+                        {
+                            usilOperand.immValueFloat = new float[mask.Length];
+                            for (int i = 0; i < mask.Length; i++)
+                            {
+                                usilOperand.immValueFloat[i] = ConvertFloatToInt((float)dxOperand.immValues[mask[i]]);
+                            }
+                        }
+                        else if (mask.Length > 0)
                         {
                             usilOperand.immValueFloat = new float[mask.Length];
                             for (int i = 0; i < mask.Length; i++)
                             {
                                 usilOperand.immValueFloat[i] = (float)dxOperand.immValues[mask[i]];
+                            }
+                        }
+                        else
+                        {
+                            usilOperand.immValueFloat = new float[dxOperand.immValues.Length];
+                            for (int i = 0; i < dxOperand.immValues.Length; i++)
+                            {
+                                usilOperand.immValueFloat[i] = (float)dxOperand.immValues[i];
                             }
                         }
                     }

--- a/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
+++ b/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
@@ -1288,8 +1288,8 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
 
             int[] mask = new int[] { 0, 1 };
             FillUSILOperand(dest, usilDest, dest.swizzle, false);
-            FillUSILOperand(src0, usilSrc0, MapMask(mask, src0.swizzle), false);
-            FillUSILOperand(src1, usilSrc1, MapMask(mask, src1.swizzle), false);
+            FillUSILOperand(src0, usilSrc0, src0.swizzle.Length >= 2 ? src0.swizzle[..2] : src0.swizzle, false);
+            FillUSILOperand(src1, usilSrc1, src1.swizzle.Length >= 2 ? src1.swizzle[..2] : src1.swizzle, false);
 
             usilInst.instructionType = USILInstructionType.DotProduct2;
             usilInst.destOperand = usilDest;
@@ -1316,8 +1316,8 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
 
             int[] mask = new int[] { 0, 1, 2 };
             FillUSILOperand(dest, usilDest, dest.swizzle, false);
-            FillUSILOperand(src0, usilSrc0, MapMask(mask, src0.swizzle), false);
-            FillUSILOperand(src1, usilSrc1, MapMask(mask, src1.swizzle), false);
+            FillUSILOperand(src0, usilSrc0, src0.swizzle.Length >= 3 ? src0.swizzle[..3] : src0.swizzle, false);
+            FillUSILOperand(src1, usilSrc1, src1.swizzle.Length >= 3 ? src1.swizzle[..3] : src1.swizzle, false);
 
             usilInst.instructionType = USILInstructionType.DotProduct3;
             usilInst.destOperand = usilDest;
@@ -1344,8 +1344,8 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
 
             int[] mask = new int[] { 0, 1, 2, 3 };
             FillUSILOperand(dest, usilDest, dest.swizzle, false);
-            FillUSILOperand(src0, usilSrc0, MapMask(mask, src0.swizzle), false);
-            FillUSILOperand(src1, usilSrc1, MapMask(mask, src1.swizzle), false);
+            FillUSILOperand(src0, usilSrc0, src0.swizzle, false);
+            FillUSILOperand(src1, usilSrc1, src1.swizzle, false);
 
             usilInst.instructionType = USILInstructionType.DotProduct4;
             usilInst.destOperand = usilDest;

--- a/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
+++ b/USCSandbox/UltraShaderConverter/UShader/DirectX/DirectXProgramToUSIL.cs
@@ -1316,9 +1316,9 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Direct
 
             int[] mask = new int[] { 0, 1 };
             FillUSILOperand(dest, usilDest, dest.swizzle, false);
-            FillUSILOperand(src0, usilSrc0, src0.swizzle.Length >= 2 ? src0.swizzle[..2] : src0.swizzle, false);
-            FillUSILOperand(src1, usilSrc1, src1.swizzle.Length >= 2 ? src1.swizzle[..2] : src1.swizzle, false);
-
+            FillUSILOperand(src0, usilSrc0, MapMask(mask, src0.swizzle), false);
+            FillUSILOperand(src1, usilSrc1, MapMask(mask, src1.swizzle), false);
+            
             usilInst.instructionType = USILInstructionType.DotProduct2;
             usilInst.destOperand = usilDest;
             usilInst.srcOperands = new List<USILOperand>

--- a/USCSandbox/UltraShaderConverter/UShader/Function/UShaderFunctionToHLSL.cs
+++ b/USCSandbox/UltraShaderConverter/UShader/Function/UShaderFunctionToHLSL.cs
@@ -171,12 +171,12 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.UShader.Functi
             }
             else
             {
-                bool hasFrontFace = _shader.inputs.Any(i => i.name == "SV_IsFrontFace");
+                var frontFace = _shader.inputs.FirstOrDefault(i => i.type == "SV_IsFrontFace");
                 string args = $"{USILConstants.VERT_TO_FRAG_STRUCT_NAME} {USILConstants.FRAG_INPUT_NAME}";
-                if (hasFrontFace)
+                if (frontFace is not null)
                 {
                     // not part of v2f
-                    args += $", float facing: VFACE";
+                    args += $", {frontFace.format} {frontFace.name}: VFACE";
                 }
                 AppendLine($"{USILConstants.FRAG_OUTPUT_STRUCT_NAME} frag({args})");
             }

--- a/USCSandbox/UltraShaderConverter/UShader/NVN/NvnProgramToUSIL.cs
+++ b/USCSandbox/UltraShaderConverter/UShader/NVN/NvnProgramToUSIL.cs
@@ -39,84 +39,9 @@ namespace USCSandbox.UltraShaderConverter.UShader.NVN
                 { Instruction.Add, new InstHandler(HandleAdd) },
                 { Instruction.Multiply | Instruction.FP32, new InstHandler(HandleMul) },
                 { Instruction.Multiply | Instruction.FP64, new InstHandler(HandleMul) },
-                //{ Instruction.Divide, new InstHandler(HandleDiv) },
                 { Instruction.FusedMultiplyAdd | Instruction.FP32, new InstHandler(HandleMad) },
                 { Instruction.FusedMultiplyAdd | Instruction.FP64, new InstHandler(HandleMad) },
-                //{ Instruction.BitwiseAnd, new InstHandler(HandleAnd) },
-                //{ Instruction.BitwiseOr, new InstHandler(HandleOr) },
-                //{ Instruction.BitwiseExclusiveOr, new InstHandler(HandleXor) },
-                //{ Instruction.BitwiseNot, new InstHandler(HandleNot) },
-                //{ Instruction.ConvertFP32ToS32, new InstHandler(HandleFtoi) },
-                //{ Instruction.ConvertFP32ToU32, new InstHandler(HandleFtoi) },
-                //{ Instruction.ConvertS32ToFP32, new InstHandler(HandleItof) },
-                //{ Instruction.ConvertU32ToFP32, new InstHandler(HandleItof) },
-                //{ Instruction.Minimum, new InstHandler(HandleMin) },
-                //{ Instruction.MinimumU32, new InstHandler(HandleMin) },
-                //{ Instruction.Maximum, new InstHandler(HandleMax) },
-                //{ Instruction.MaximumU32, new InstHandler(HandleMax) },
-                //{ Instruction.SquareRoot, new InstHandler(HandleSqrt) },
-                //{ Instruction.ReciprocalSquareRoot, new InstHandler(HandleRsq) },
-                //{ Instruction.LogarithmB2, new InstHandler(HandleLog) },
-                //{ Instruction.ExponentB2, new InstHandler(HandleExp) },
-                //{ Instruction.Negate, new InstHandler(HandleNeg) },
-                //{ Instruction.Round, new InstHandler(HandleRound) },
-                //{ Instruction.Sine, new InstHandler(HandleSin) },
-                //{ Instruction.Cosine, new InstHandler(HandleCos) },
-                //{ Instruction.ShiftLeft, new InstHandler(HandleShl) },
-                //{ Instruction.ShiftRightS32, new InstHandler(HandleIShr) },
-                //{ Instruction.ShiftRightU32, new InstHandler(HandleIShr) },
                 { Instruction.Load, new InstHandler(HandleLoad) },
-                //{ Instruction.Store, new InstHandler(HandleStore) },
-
-                //{ Instruction.dp2, new InstHandler(HandleDp2) },
-                //{ Instruction.dp3, new InstHandler(HandleDp3) },
-                //{ Instruction.dp4, new InstHandler(HandleDp4) },
-                //{ Instruction.sample, new InstHandler(HandleSample) },
-                //{ Instruction.sample_c, new InstHandler(HandleSampleC) },
-                //{ Instruction.sample_c_lz, new InstHandler(HandleSampleC) },
-                //{ Instruction.sample_l, new InstHandler(HandleSampleL) },
-                //{ Instruction.sample_b, new InstHandler(HandleSampleL) },
-                //{ Instruction.sample_d, new InstHandler(HandleSampleD) },
-                //{ Instruction.ld, new InstHandler(HandleLd) },
-                //{ Instruction.ldms, new InstHandler(HandleLd) },
-                //{ Instruction.ld_structured, new InstHandler(HandleLdStructured) },
-                //{ Instruction.discard, new InstHandler(HandleDiscard) },
-                //{ Instruction.resinfo, new InstHandler(HandleResInfo) },
-                //{ Instruction.sampleinfo, new InstHandler(HandleSampleInfo) },
-                //{ Instruction.deriv_rtx, new InstHandler(HandleDerivRt) },
-                //{ Instruction.deriv_rty, new InstHandler(HandleDerivRt) },
-                //{ Instruction.deriv_rtx_coarse, new InstHandler(HandleDerivRt) },
-                //{ Instruction.deriv_rty_coarse, new InstHandler(HandleDerivRt) },
-                //{ Instruction.deriv_rtx_fine, new InstHandler(HandleDerivRt) },
-                //{ Instruction.deriv_rty_fine, new InstHandler(HandleDerivRt) },
-                //{ Instruction.@if, new InstHandler(HandleIf) },
-                //{ Instruction.@else, new InstHandler(HandleElse) },
-                //{ Instruction.endif, new InstHandler(HandleEndIf) },
-                //{ Instruction.loop, new InstHandler(HandleLoop) },
-                //{ Instruction.endloop, new InstHandler(HandleEndLoop) },
-                //{ Instruction.@break, new InstHandler(HandleBreak) },
-                //{ Instruction.breakc, new InstHandler(HandleBreakc) },
-                //{ Instruction.@continue, new InstHandler(HandleContinue) },
-                //{ Instruction.continuec, new InstHandler(HandleContinuec) },
-                //{ Instruction.@switch, new InstHandler(HandleSwitch) },
-                //{ Instruction.@case, new InstHandler(HandleCase) },
-                //{ Instruction.@default, new InstHandler(HandleDefault) },
-                //{ Instruction.endswitch, new InstHandler(HandleEndSwitch) },
-                //{ Instruction.eq, new InstHandler(HandleEq) },
-                //{ Instruction.ieq, new InstHandler(HandleEq) },
-                //{ Instruction.ne, new InstHandler(HandleNeq) },
-                //{ Instruction.ine, new InstHandler(HandleNeq) },
-                //{ Instruction.lt, new InstHandler(HandleLt) },
-                //{ Instruction.ilt, new InstHandler(HandleLt) },
-                //{ Instruction.ult, new InstHandler(HandleLt) },
-                //{ Instruction.ge, new InstHandler(HandleGe) },
-                //{ Instruction.ige, new InstHandler(HandleGe) },
-                //{ Instruction.uge, new InstHandler(HandleGe) },
-                //{ Instruction.ret, new InstHandler(HandleRet) },
-                //////dec
-                //{ Opcode.dcl_temps, new InstHandler(HandleTemps) },
-                //{ Opcode.dcl_resource, new InstHandler(HandleResource) },
-                //{ Opcode.customdata, new InstHandler(HandleCustomData) }
             };
 
             // locals are not ID'd but pointers to specific operands
@@ -130,8 +55,6 @@ namespace USCSandbox.UltraShaderConverter.UShader.NVN
             GenerateRyujinxIl();
             ConvertInstructions();
             var a = 2;
-            //ConvertInputs();
-            //ConvertOutputs();
         }
 
         private void GenerateRyujinxIl()
@@ -216,7 +139,6 @@ namespace USCSandbox.UltraShaderConverter.UShader.NVN
                     else
                     {
                         // unsupported
-                        //SetUsilOperandImmediate(usilOperand, 12345, 12345f, immIsInt);
                         usilOperand.operandType = USILOperandType.Comment;
                         usilOperand.comment = $"/*{mxOperand.Type}/{mxOperand.Value}/{reg.Type}/1*/";
                     }
@@ -226,7 +148,6 @@ namespace USCSandbox.UltraShaderConverter.UShader.NVN
                 {
                     usilOperand.operandType = USILOperandType.Comment;
                     usilOperand.comment = $"/*{mxOperand.Type}/{mxOperand.Value}/2*/";
-                    //SetUsilOperandImmediate(usilOperand, 23456, 23456f, immIsInt);
                     break;
                 }
             }
@@ -357,8 +278,6 @@ namespace USCSandbox.UltraShaderConverter.UShader.NVN
                 USILOperand usilSrc0 = new USILOperand();
 
                 FillUSILOperand(dest, usilDest, false);
-                //FillUSILOperand(src0, usilSrc0, false);
-                //FillUSILOperand(src1, usilSrc1, false);
                 usilSrc0.operandType = USILOperandType.Comment;
                 usilSrc0.comment = $"/*{io}, {src1.Value}*/";
 


### PR DESCRIPTION
For the past week, I found that I could actually get very close to recovering all the shaders in Bug Fables: The Everlasting Sapling thanks to the yaml assets export option in AssetRipper. USC was more advanced than the AssetRipper decompiler, so I tried to fix things and implement things on usc enough to get to a point where all shaders are recoverded.

I succeeded, but it took a lot of changes. I tried my best to segment the commits with high level explanations, but unfortunately, too much happened for this to be the cleanest. I am especially annoyed at ShaderProcessor being hard to follow from the diff, but it will do for now.

The commits list gives a good high level overview of what I had to do, but the biggest one is worth talking about: shaders variants.

The biggest issue I was running into was that either decompilers was not including all the variants needed. Some of these are needed for the materials to receive lighting or shadows so it made a very big difference to have them. I solved this by completely changing the structure of how we decompile sub programs.

First, we no longer try to pair them, we just have one basket with everything in it. This means it will decompile all vertex followed by all fragments. I also had to make each shader decompile their own struct, cbuffers and textures because I found they can differ between variants. Unfortunately, this means this is EXTREMELY inneficient: files grows by thousands of lines in worst cases because a lot of the code or declarations gets repeated. Further optimisations can be done later to merge the common stuff, but I just cared for accuracy at the moment.

Second, keywords. How this is done is we first build a list of multi_compile and shader_feature directives to map out the list of keywords combinations we want and select the variant via an `#if`, `#elif`, `#else` `#endif` chain. Due to how this chain works logically, it is best to have every shaders sorted from most specific to least (after sorting them by types) so it allows us to test just the keywords that are enabled in the ifs and add a falback else clause on the last one so we guarantee one shader is selected.

Unfortunately, this keywords mapping isn't 1:1: Unity doesn't allow to have a specific set of keywords to be a variant, it only allows to declare sets where each will be one. This complicates our lives because we now have to specify enough directive to include everything, but some overgenerations is unavoidable. The sweetspot I got was the following:

1. If a keyword is always there, put a multi_compile with just that keyword which forces it on
2. Excluding the mandatory keywords found above, considering all the combinations with the least amounts of keywords, make multi_compile directives for each indexes until we cover the least amount of keywords possible
3. For everything else, put a shader_feature with that keyword which makes it completely optional

With all the changes done, I was able to fully recover all shaders from the game.