### PR TITLE
Update AssetRipper.Primitives dependency to v3.2.0 via NuGet

### DIFF
--- a/USCSandbox/Processor/BlobEntry.cs
+++ b/USCSandbox/Processor/BlobEntry.cs
@@ -12,7 +12,7 @@ namespace USCSandbox.Processor
         {
             Offset = reader.ReadInt32();
             Length = reader.ReadInt32();
-            if (engVer.IsGreaterEqual(2019, 3))
+            if (engVer.GreaterThanOrEquals(2019, 3))
             {
                 Segment = reader.ReadInt32();
             }

--- a/USCSandbox/Processor/ConstantBuffer.cs
+++ b/USCSandbox/Processor/ConstantBuffer.cs
@@ -27,7 +27,7 @@ namespace USCSandbox.Processor
                 CBParams.Add(new ConstantBufferParameter(r));
             }
 
-            bool hasStructParams = engVer.IsGreaterEqual(2017, 3);
+            bool hasStructParams = engVer.GreaterThanOrEquals(2017, 3);
             if (hasStructParams)
             {
                 var structCount = r.ReadInt32();

--- a/USCSandbox/Processor/ShaderSubProgram.cs
+++ b/USCSandbox/Processor/ShaderSubProgram.cs
@@ -21,8 +21,8 @@ namespace USCSandbox.Processor
 
         public ShaderSubProgram(AssetsFileReader r, UnityVersion version)
         {
-            var hasStatsTempRegister = version.IsGreaterEqual(5, 5);
-            var hasLocalKeywords = version.IsLess(2021, 2) && version.IsGreaterEqual(2019, 1);
+            var hasStatsTempRegister = version.GreaterThanOrEquals(5, 5);
+            var hasLocalKeywords = version.LessThan(2021, 2) && version.GreaterThanOrEquals(2019, 1);
 
             var blobVersion = r.ReadInt32();
             ProgramType = r.ReadInt32();
@@ -62,7 +62,7 @@ namespace USCSandbox.Processor
 
             BindChannels = new ParserBindChannels(r);
 
-            if (version.IsLess(2021))
+            if (version.LessThan(2021))
             {
                 ShaderParams = new ShaderParams(r, version, false);
             }
@@ -70,7 +70,7 @@ namespace USCSandbox.Processor
 
         public ShaderGpuProgramType GetProgramType(UnityVersion version)
         {
-            if (version.IsGreaterEqual(5, 5))
+            if (version.GreaterThanOrEquals(5, 5))
             {
                 return ((ShaderGpuProgramType55)ProgramType).ToGpuProgramType();
             }

--- a/USCSandbox/Processor/TextureParameter.cs
+++ b/USCSandbox/Processor/TextureParameter.cs
@@ -19,8 +19,8 @@ namespace USCSandbox.Processor
             Name = name;
             Index = index;
 
-            var hasNewTextureParams = engVer.IsGreaterEqual(2018, 2);
-            var hasMultiSampled = engVer.IsGreaterEqual(2017, 3);
+            var hasNewTextureParams = engVer.GreaterThanOrEquals(2018, 2);
+            var hasMultiSampled = engVer.GreaterThanOrEquals(2017, 3);
             if (hasNewTextureParams)
             {
                 var textureExtraValue = r.ReadUInt32();

--- a/USCSandbox/USCSandbox.csproj
+++ b/USCSandbox/USCSandbox.csproj
@@ -9,9 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Reference Include="AssetRipper.Primitives">
-      <HintPath>..\Libs\AssetRipper.Primitives.dll</HintPath>
-    </Reference>
+    <PackageReference Include="AssetRipper.Primitives" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="AssetsTools.NET">
       <HintPath>..\Libs\AssetsTools.NET.dll</HintPath>
     </Reference>

--- a/USCSandbox/UltraShaderConverter/Converter/USCShaderConverter.cs
+++ b/USCSandbox/UltraShaderConverter/Converter/USCShaderConverter.cs
@@ -32,7 +32,7 @@ namespace AssetRipper.Export.Modules.Shaders.UltraShaderConverter.Converter
             bool hasHeader = graphicApi != GPUPlatform.d3d9;
             if (hasHeader)
             {
-                bool hasGSInputPrimitive = version.IsGreaterEqual(5, 4);
+                bool hasGSInputPrimitive = version.GreaterThanOrEquals(5, 4);
                 int offset = hasGSInputPrimitive ? 6 : 5;
                 if (headerVersion >= 2)
                 {


### PR DESCRIPTION
Hi,
I am currently working on a Hook-based custom engine unpacking framework and plan to use this project for shader decompilation (since recent versions of AssetRipper have removed this feature).
However, I encountered a MethodNotFound exception at runtime. This is because my runtime environment loads the latest version (3.2.0) of AssetRipper.Primitives, which conflicts with the older local DLL reference in this project.
Changes in this PR:
Dependency Update: Replaced the local DLL reference in the .csproj file with the AssetRipper.Primitives (v3.2.0) NuGet package.
API Fixes: Updated method names in 5 files to address API changes introduced in the new version.
This update ensures compatibility with the latest AssetRipper libraries.
Thanks!