### PR TITLE
Create GitHub Actions workflow

### DIFF
--- a/.github/workflows/build_usc.yml
+++ b/.github/workflows/build_usc.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-usc-sandbox:
-    name: Build USC Sandbox for ${{ matrix.os }}
+    name: Build ${{ matrix.configuration}} binaries for USC Sandbox on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -44,4 +44,4 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: "USCSandbox-${{ matrix.configuration }}-${{ steps.git-head-check.outputs.GIT_REF }}-${{ matrix.os }}"
-          path: ./USCSandbox/bin/Release/net8.0/*
+          path: ./USCSandbox/bin/${{ matrix.configuration }}/net8.0/*

--- a/.github/workflows/build_usc.yml
+++ b/.github/workflows/build_usc.yml
@@ -15,6 +15,9 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+        configuration:
+          - Debug
+          - Release
     steps:
       - uses: actions/checkout@v6
 
@@ -29,7 +32,7 @@ jobs:
 
       - name: Build solution
         run: |
-          dotnet build -c Release
+          dotnet build -c ${{ matrix.configuration }}
 
       - name: Get git HEAD
         id: git-head-check
@@ -40,5 +43,5 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: "USCSandbox-${{ steps.git-head-check.outputs.GIT_REF }}-${{ matrix.os }}"
+          name: "USCSandbox-${{ matrix.configuration }}-${{ steps.git-head-check.outputs.GIT_REF }}-${{ matrix.os }}"
           path: ./USCSandbox/bin/Release/net8.0/*

--- a/.github/workflows/build_usc.yml
+++ b/.github/workflows/build_usc.yml
@@ -1,0 +1,37 @@
+name: Build USC Sandbox
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build-usc-sandbox:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up .NET 8.0
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+
+      - name: Install dependencies
+        run: |
+          dotnet restore
+
+      - name: Build solution
+        run: |
+          dotnet build -c Release
+
+      - name: Get git revision
+        id: git-revision-check
+        shell: bash
+        run: |
+          export GIT_REF="${GITHUB_REF##*/}"
+          echo "GIT_REF=${GIT_REF}" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: "USCSandbox-${{ steps.git-revision-check.outputs.GIT_REF }}"
+          path: ./USCSandbox/bin/Release/net8.0/*

--- a/.github/workflows/build_usc.yml
+++ b/.github/workflows/build_usc.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   build-usc-sandbox:
-    runs-on: ubuntu-latest
+    name: Build USC Sandbox for ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -24,14 +31,14 @@ jobs:
         run: |
           dotnet build -c Release
 
-      - name: Get git revision
-        id: git-revision-check
+      - name: Get git HEAD
+        id: git-head-check
         shell: bash
         run: |
-          export GIT_REF="${GITHUB_REF##*/}"
-          echo "GIT_REF=${GIT_REF}" >> $GITHUB_OUTPUT
+          export GIT_HEAD="${GITHUB_REF#*/*/}"
+          echo "GIT_HEAD=${GIT_HEAD//\//__}" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@v7
         with:
-          name: "USCSandbox-${{ steps.git-revision-check.outputs.GIT_REF }}"
+          name: "USCSandbox-${{ steps.git-head-check.outputs.GIT_REF }}-${{ matrix.os }}"
           path: ./USCSandbox/bin/Release/net8.0/*

--- a/.github/workflows/build_usc.yml
+++ b/.github/workflows/build_usc.yml
@@ -43,5 +43,5 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: "USCSandbox-${{ matrix.configuration }}-${{ steps.git-head-check.outputs.GIT_REF }}-${{ matrix.os }}"
+          name: "USCSandbox-${{ matrix.configuration }}-${{ steps.git-head-check.outputs.GIT_HEAD }}-${{ matrix.os }}"
           path: ./USCSandbox/bin/${{ matrix.configuration }}/net8.0/*


### PR DESCRIPTION
This adds a GitHub Actions workflow to the repository, automatically building binaries for all platforms on commits or pull requests.

You can see an example of what the run looks like [here](https://github.com/scarletcafe/USCSandbox/actions/runs/24965036433). If you scroll to the bottom you can download the artifacts GitHub Actions has produced.

You could use this to confirm that incoming changes don't break builds, but honestly I only wrote this workflow so that I don't have to worry about fetching and compiling things myself.